### PR TITLE
.NET Core support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,5 @@ pip-log.txt
 # Mac crap
 .DS_Store
 
+# .NET Core artifacts
+*.lock.json

--- a/LtiLibrary.AspNet.Tests/LtiLibrary.AspNet.Tests.csproj
+++ b/LtiLibrary.AspNet.Tests/LtiLibrary.AspNet.Tests.csproj
@@ -44,10 +44,19 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
       <Private>True</Private>
@@ -122,7 +131,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/LtiLibrary.AspNet.Tests/packages.config
+++ b/LtiLibrary.AspNet.Tests/packages.config
@@ -2,6 +2,9 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" userInstalled="true" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" userInstalled="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" userInstalled="true" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" userInstalled="true" />

--- a/LtiLibrary.AspNet/LtiLibrary.AspNet.csproj
+++ b/LtiLibrary.AspNet/LtiLibrary.AspNet.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>LtiLibrary.AspNet</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,10 +46,19 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -114,6 +125,13 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/LtiLibrary.AspNet/packages.config
+++ b/LtiLibrary.AspNet/packages.config
@@ -4,5 +4,8 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" userInstalled="true" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/LtiLibrary.Core.Tests/LtiLibrary.Core.Tests.csproj
+++ b/LtiLibrary.Core.Tests/LtiLibrary.Core.Tests.csproj
@@ -51,6 +51,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
@@ -132,7 +142,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/LtiLibrary.Core.Tests/packages.config
+++ b/LtiLibrary.Core.Tests/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" userInstalled="true" />
   <package id="NodaTime" version="1.3.1" targetFramework="net45" userInstalled="true" />
   <package id="NodaTime.Serialization.JsonNet" version="1.3.1" targetFramework="net45" userInstalled="true" />

--- a/LtiLibrary.Core/Common/JsonLdObjectContractResolver.cs
+++ b/LtiLibrary.Core/Common/JsonLdObjectContractResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Newtonsoft.Json.Serialization;
+using System.Reflection;
 
 namespace LtiLibrary.Core.Common
 {

--- a/LtiLibrary.Core/Common/JsonLdObjectConverter.cs
+++ b/LtiLibrary.Core/Common/JsonLdObjectConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/LtiLibrary.Core/Common/LtiConstants.cs
+++ b/LtiLibrary.Core/Common/LtiConstants.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using LtiLibrary.Core.Lti1;
+using System.Linq;
 
 namespace LtiLibrary.Core.Common
 {
@@ -11,12 +13,12 @@ namespace LtiLibrary.Core.Common
         // Build a lookup table of role URNs
         static LtiConstants()
         {
-            RoleUrns =  new Dictionary<string, Role>(StringComparer.InvariantCultureIgnoreCase);
+            RoleUrns =  new Dictionary<string, Role>(StringComparer.OrdinalIgnoreCase);
             var type = typeof(Role);
             foreach (Role role in Enum.GetValues(type))
             {
-                var memInfo = type.GetMember(role.ToString());
-                var attributes = memInfo[0].GetCustomAttributes(typeof(UrnAttribute), false);
+                var memInfo = type.GetTypeInfo().GetMember(role.ToString());
+                var attributes = memInfo[0].GetCustomAttributes(typeof(UrnAttribute), false).ToArray();
                 var urn = ((UrnAttribute)attributes[0]).Urn;
                 RoleUrns.Add(urn, role);
             }

--- a/LtiLibrary.Core/Extensions/HttpContentType.cs
+++ b/LtiLibrary.Core/Extensions/HttpContentType.cs
@@ -1,0 +1,9 @@
+﻿using System.Net.Http.Headers;
+
+namespace LtiLibrary.Core.Extensions
+{
+    public static class HttpContentType
+    {
+        public static readonly MediaTypeHeaderValue Xml = new MediaTypeHeaderValue("application/xml");
+    }
+}

--- a/LtiLibrary.Core/Extensions/HttpExtensions.cs
+++ b/LtiLibrary.Core/Extensions/HttpExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace LtiLibrary.Core.Extensions
+{
+    internal static class HttpExtensions
+    {
+        public static async Task<HttpResponseMessage> GetResponseAsync(this HttpRequestMessage message, bool allowAutoRedirect = false)
+        {
+            using (var handler = new HttpClientHandler() { AllowAutoRedirect = allowAutoRedirect })
+            {
+                using (var client = new HttpClient(handler))
+                {
+                    return await client.SendAsync(message);
+                }
+            }
+        }
+
+        public static HttpResponseMessage GetResponse(this HttpRequestMessage message, bool allowAutoRedirect = false)
+        {
+            return GetResponseAsync(message, allowAutoRedirect).Result;
+        }
+
+        public static Stream GetRequestStream(this HttpRequestMessage message)
+        {
+            return message.Content.ReadAsStreamAsync().Result;
+        }
+
+        public static Stream GetResponseStream(this HttpResponseMessage message)
+        {
+            return message.Content.ReadAsStreamAsync().Result;
+        }
+        
+    }
+}

--- a/LtiLibrary.Core/Extensions/HttpWebRequestExtensions.cs
+++ b/LtiLibrary.Core/Extensions/HttpWebRequestExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Text;
 
 namespace LtiLibrary.Core.Extensions
@@ -10,15 +11,15 @@ namespace LtiLibrary.Core.Extensions
         /// Create a string representation of the <see cref="HttpWebRequest"/> similar to Fiddler's.
         /// </summary>
         /// <remarks>Created for learning and debugging LTI.</remarks>
-        public static string ToFormattedRequestString(this HttpWebRequest request)
+        public static string ToFormattedRequestString(this HttpRequestMessage request)
         {
             var sb = new StringBuilder();
             sb.AppendFormat("{0} {1} HTTP/1.1\n", request.Method, request.RequestUri);
-            foreach (var key in request.Headers.AllKeys)
+            foreach (var header in request.Headers)
             {
-                sb.AppendFormat("{0}: {1}\n", key, string.Join(",", request.Headers.GetValues(key) ?? new string[]{}));
+                sb.AppendFormat("{0}: {1}\n", header.Key, string.Join(",", header.Value ?? new string[]{}));
             }
-            if (request.ContentLength > 0)
+            if (request.Content.Headers.ContentLength > 0)
             {
                 sb.AppendLine();
                 using (var stream = request.GetRequestStream())

--- a/LtiLibrary.Core/Extensions/HttpWebResponseExtensions.cs
+++ b/LtiLibrary.Core/Extensions/HttpWebResponseExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Net.Http;
 using System.Text;
 
 namespace LtiLibrary.Core.Extensions
@@ -10,15 +11,15 @@ namespace LtiLibrary.Core.Extensions
         /// Create a string representation of the <see cref="HttpWebResponse"/> similar to Fiddler's.
         /// </summary>
         /// <remarks>Created for learning and debugging LTI.</remarks>
-        public static string ToFormattedResponseString(this HttpWebResponse response, string body)
+        public static string ToFormattedResponseString(this HttpResponseMessage response, string body)
         {
             var sb = new StringBuilder();
             sb.AppendFormat("HTTP/1.1 {0} {1}\n", Convert.ToInt32(response.StatusCode), response.StatusCode);
-            foreach (var key in response.Headers.AllKeys)
+            foreach (var header in response.Headers)
             {
-                sb.AppendFormat("{0}: {1}\n", key, string.Join(",", response.Headers.GetValues(key) ?? new string[] { }));
+                sb.AppendFormat("{0}: {1}\n", header.Key, string.Join(",", header.Value ?? new string[] { }));
             }
-            if (response.ContentLength > 0)
+            if (response.Content.Headers.ContentLength > 0)
             {
                 sb.AppendLine();
                 sb.Append(body);

--- a/LtiLibrary.Core/Extensions/JsonLdExtensions.cs
+++ b/LtiLibrary.Core/Extensions/JsonLdExtensions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using LtiLibrary.Core.Common;
 using Newtonsoft.Json;
+using System.Net.Http;
 
 namespace LtiLibrary.Core.Extensions
 {
@@ -44,7 +45,7 @@ namespace LtiLibrary.Core.Extensions
         /// <summary>
         /// Deserializes the JSON response to the specified .NET type.
         /// </summary>
-        public static T DeserializeObject<T>(this HttpWebResponse response)
+        public static T DeserializeObject<T>(this HttpResponseMessage response)
         {
             try
             {

--- a/LtiLibrary.Core/Extensions/PlatformSpecific.cs
+++ b/LtiLibrary.Core/Extensions/PlatformSpecific.cs
@@ -1,0 +1,78 @@
+﻿namespace LtiLibrary.Core.Extensions
+{
+    using System;
+
+#if NetCore
+    using Sha1 = System.Security.Cryptography.SHA1;
+#else
+    using Sha1 = System.Security.Cryptography.SHA1CryptoServiceProvider;
+#endif
+
+    /// <summary>
+    /// Contains platform specific implementations.
+    /// </summary>
+    public static class PlatformSpecific
+    {
+        private static readonly char[] HexUpperChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+
+        /// <summary>
+        /// Converts a specified character into its hexadecimal equivalent.
+        /// </summary>
+        /// <param name="character">The character to convert to hexadecimal representation.</param>
+        /// <returns>The hexadecimal representation of the specified character.</returns>
+        public static string HexEscape(char character)
+        {
+            // .Net Core doesn't have escape function.
+#if NetCore
+            if (character > '\xff')
+            {
+                throw new ArgumentOutOfRangeException(nameof(character));
+            }
+
+            return "%" + HexUpperChars[((character & 0xf0) >> 4)] + HexUpperChars[((character & 0x0f))];
+#else
+            return Uri.HexEscape(character);
+#endif
+        }
+
+        /// <summary>
+        /// Gets SHA1 implementation.
+        /// </summary>
+        /// <returns><see cref="Sha1"/>.</returns>
+        public static Sha1 GetSha1Provider()
+        {
+#if NetCore
+            return Sha1.Create();
+#else
+            return new Sha1();
+#endif
+        }
+    }
+}
+
+#if NetCore
+
+namespace System
+{
+    /// <summary>
+    /// Empty attribute for backward compatability.
+    /// </summary>
+    public class SerializableAttribute : Attribute
+    {
+    }
+}
+
+namespace System.ComponentModel
+{
+    /// <summary>
+    /// Empty attribute for backward compatability. TODO: Seems like since RC3 this class will be included into official nuget package.
+    /// </summary>
+    public class DesignerCategoryAttribute : Attribute
+    {
+        public DesignerCategoryAttribute(string name)
+        {
+        }
+    }
+}
+
+#endif

--- a/LtiLibrary.Core/Extensions/StringExtensions.cs
+++ b/LtiLibrary.Core/Extensions/StringExtensions.cs
@@ -39,7 +39,7 @@ namespace LtiLibrary.Core.Extensions
             // Upgrade the escaping to RFC 3986, if necessary.
             foreach (var s in UriRfc3986CharsToEscape)
             {
-                escaped.Replace(s, Uri.HexEscape(s[0]));
+                escaped.Replace(s, PlatformSpecific.HexEscape(s[0]));
             }
 
             // Return the fully-RFC3986-escaped string.

--- a/LtiLibrary.Core/LtiLibrary.Core.csproj
+++ b/LtiLibrary.Core/LtiLibrary.Core.csproj
@@ -17,6 +17,8 @@
     <SccProvider>SAK</SccProvider>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,6 +51,15 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -64,6 +75,8 @@
     <Compile Include="ContentItems\ContentItemSelectionGraph.cs" />
     <Compile Include="ContentItems\LtiLink.cs" />
     <Compile Include="Extensions\HttpContentExtensions.cs" />
+    <Compile Include="Extensions\HttpContentType.cs" />
+    <Compile Include="Extensions\HttpExtensions.cs" />
     <Compile Include="Extensions\HttpWebRequestExtensions.cs" />
     <Compile Include="Extensions\HttpWebResponseExtensions.cs" />
     <Compile Include="Extensions\NameValueCollectionExtensions.cs" />
@@ -154,6 +167,13 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/LtiLibrary.Core/LtiLibrary.Core.csproj
+++ b/LtiLibrary.Core/LtiLibrary.Core.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Common\LtiException.cs" />
     <Compile Include="ContentItems\ContentItem.cs" />
     <Compile Include="ContentItems\ContentItemPlacement.cs" />
+    <Compile Include="Extensions\PlatformSpecific.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Lti1\DocumentTarget.cs" />
     <Compile Include="Lti1\IBasicLaunchRequest.cs" />

--- a/LtiLibrary.Core/LtiLibrary.Core.project.json
+++ b/LtiLibrary.Core/LtiLibrary.Core.project.json
@@ -1,0 +1,8 @@
+﻿{
+  "frameworks": {
+    "net45": { }
+  },
+  "runtimes": {
+    "win":  { }
+  }
+}

--- a/LtiLibrary.Core/LtiLibrary.Core.xproj
+++ b/LtiLibrary.Core/LtiLibrary.Core.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>e5dd5c8b-9b8c-4985-8c2a-a381dce68f1a</ProjectGuid>
+    <RootNamespace>LtiLibrary.Core</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <DnxInvisibleFolder Include=".vs\" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
@@ -9,6 +9,9 @@ using System.Xml.Serialization;
 using LtiLibrary.Core.Common;
 using LtiLibrary.Core.Extensions;
 using LtiLibrary.Core.OAuth;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
 
 namespace LtiLibrary.Core.Outcomes.v1
 {
@@ -60,7 +63,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                     serviceUrl,
                     consumerKey,
                     consumerSecret);
-                var webResponse = webRequest.GetResponse() as HttpWebResponse;
+                var webResponse = webRequest.GetResponse();
                 return ParseDeleteResultResponse(webResponse);
             }
             catch (Exception ex)
@@ -107,7 +110,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                     serviceUrl,
                     consumerKey,
                     consumerSecret);
-                var webResponse = webRequest.GetResponse() as HttpWebResponse;
+                var webResponse = webRequest.GetResponse();
                 return ParsePostResultResponse(webResponse);
             }
             catch (Exception ex)
@@ -153,7 +156,7 @@ namespace LtiLibrary.Core.Outcomes.v1
             return imsxEnvelope != null;
         }
 
-        private static BasicResult ParseDeleteResultResponse(HttpWebResponse webResponse)
+        private static BasicResult ParseDeleteResultResponse(HttpResponseMessage webResponse)
         {
             if (webResponse == null) return new BasicResult(false, "Invalid webResponse");
 
@@ -172,7 +175,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                 imsxHeader.imsx_statusInfo.imsx_description);
         }
 
-        private static BasicResult ParsePostResultResponse(HttpWebResponse webResponse)
+        private static BasicResult ParsePostResultResponse(HttpResponseMessage webResponse)
         {
             if (webResponse == null) return new BasicResult(false, "Invalid webResponse");
 
@@ -216,7 +219,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                     serviceUrl,
                     consumerKey,
                     consumerSecret);
-                var webResponse = webRequest.GetResponse() as HttpWebResponse;
+                var webResponse = webRequest.GetResponse();
                 return ParseReadResultResponse(webResponse);
             }
             catch (Exception ex)
@@ -225,7 +228,7 @@ namespace LtiLibrary.Core.Outcomes.v1
             }
         }
 
-        private static LisResult ParseReadResultResponse(WebResponse webResponse)
+        private static LisResult ParseReadResultResponse(HttpResponseMessage webResponse)
         {
             if (webResponse == null)
             {
@@ -262,12 +265,10 @@ namespace LtiLibrary.Core.Outcomes.v1
             return new LisResult { Score = null, IsValid = true };
         }
 
-        private static HttpWebRequest CreateLtiOutcomesRequest(imsx_POXEnvelopeType imsxEnvelope, string url, string consumerKey, string consumerSecret)
+        private static HttpRequestMessage CreateLtiOutcomesRequest(imsx_POXEnvelopeType imsxEnvelope, string url, string consumerKey, string consumerSecret)
         {
-            var webRequest = (HttpWebRequest) WebRequest.Create(url);
-            webRequest.Method = "POST";
-            webRequest.ContentType = "application/xml";
-
+            var webRequest = new HttpRequestMessage(HttpMethod.Post, url);
+            
             var parameters = new NameValueCollection();
             parameters.AddParameter(OAuthConstants.ConsumerKeyParameter, consumerKey);
             parameters.AddParameter(OAuthConstants.NonceParameter, Guid.NewGuid().ToString());
@@ -285,7 +286,8 @@ namespace LtiLibrary.Core.Outcomes.v1
             {
                 ImsxRequestSerializer.Serialize(ms, imsxEnvelope);
                 ms.Position = 0;
-                ms.CopyTo(webRequest.GetRequestStream());
+                webRequest.Content = new StreamContent(ms);
+                webRequest.Content.Headers.ContentType = HttpContentType.Xml;
 
                 var hash = sha1.ComputeHash(ms.ToArray());
                 var hash64 = Convert.ToBase64String(hash);
@@ -293,7 +295,7 @@ namespace LtiLibrary.Core.Outcomes.v1
             }
 
             // Calculate the signature
-            var signature = OAuthUtility.GenerateSignature(webRequest.Method, webRequest.RequestUri, parameters,
+            var signature = OAuthUtility.GenerateSignature(webRequest.Method.Method.ToUpper(), webRequest.RequestUri, parameters,
                 consumerSecret);
             parameters.AddParameter(OAuthConstants.SignatureParameter, signature);
 
@@ -303,7 +305,7 @@ namespace LtiLibrary.Core.Outcomes.v1
             {
                 authorization.AppendFormat("{0}=\"{1}\",", key, WebUtility.UrlEncode(parameters[key]));
             }
-            webRequest.Headers["Authorization"] = authorization.ToString(0, authorization.Length - 1);
+            webRequest.Content.Headers.Add("Authorization", authorization.ToString(0, authorization.Length - 1));
 
             return webRequest;
         }

--- a/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v1/OutcomesClient.cs
@@ -94,7 +94,7 @@ namespace LtiLibrary.Core.Outcomes.v1
                     {
                         language = LtiConstants.ScoreLanguage,
                         textString = score.HasValue
-                            ? score.Value.ToString(CultureInfo.CreateSpecificCulture(LtiConstants.ScoreLanguage))
+                            ? score.Value.ToString(new CultureInfo(LtiConstants.ScoreLanguage))
                             : null
                     }
                 }
@@ -268,7 +268,7 @@ namespace LtiLibrary.Core.Outcomes.v1
         private static HttpRequestMessage CreateLtiOutcomesRequest(imsx_POXEnvelopeType imsxEnvelope, string url, string consumerKey, string consumerSecret)
         {
             var webRequest = new HttpRequestMessage(HttpMethod.Post, url);
-            
+
             var parameters = new NameValueCollection();
             parameters.AddParameter(OAuthConstants.ConsumerKeyParameter, consumerKey);
             parameters.AddParameter(OAuthConstants.NonceParameter, Guid.NewGuid().ToString());
@@ -282,7 +282,7 @@ namespace LtiLibrary.Core.Outcomes.v1
 
             // Calculate the body hash
             using (var ms = new MemoryStream())
-            using (var sha1 = new SHA1CryptoServiceProvider())
+            using (var sha1 = PlatformSpecific.GetSha1Provider())
             {
                 ImsxRequestSerializer.Serialize(ms, imsxEnvelope);
                 ms.Position = 0;
@@ -305,7 +305,7 @@ namespace LtiLibrary.Core.Outcomes.v1
             {
                 authorization.AppendFormat("{0}=\"{1}\",", key, WebUtility.UrlEncode(parameters[key]));
             }
-            webRequest.Content.Headers.Add("Authorization", authorization.ToString(0, authorization.Length - 1));
+            webRequest.Content.Headers.Add(OAuthConstants.AuthorizationHeader, authorization.ToString(0, authorization.Length - 1));
 
             return webRequest;
         }

--- a/LtiLibrary.Core/Outcomes/v2/OutcomesClient.cs
+++ b/LtiLibrary.Core/Outcomes/v2/OutcomesClient.cs
@@ -448,7 +448,7 @@ namespace LtiLibrary.Core.Outcomes.v2
             parameters.AddParameter(OAuthConstants.TimestampParameter, timestamp);
 
             // Calculate the body hash
-            using (var sha1 = new SHA1CryptoServiceProvider())
+            using (var sha1 = PlatformSpecific.GetSha1Provider())
             {
                 var hash = sha1.ComputeHash(body);
                 var hash64 = Convert.ToBase64String(hash);
@@ -466,7 +466,7 @@ namespace LtiLibrary.Core.Outcomes.v2
             {
                 authorization.AppendFormat("{0}=\"{1}\",", key, WebUtility.UrlEncode(parameters[key]));
             }
-            request.Content.Headers.Add("Authorization", authorization.ToString(0, authorization.Length - 1));
+            request.Content.Headers.Add(OAuthConstants.AuthorizationHeader, authorization.ToString(0, authorization.Length - 1));
         }
 
         #endregion

--- a/LtiLibrary.Core/packages.config
+++ b/LtiLibrary.Core/packages.config
@@ -1,4 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/LtiLibrary.Core/project.json
+++ b/LtiLibrary.Core/project.json
@@ -1,0 +1,82 @@
+{
+  "title": "LtiLibrary.Core",
+  "version": "1.6-*",
+  "authors": [ "andyfmiller.com" ],
+  "description": ".NET library with IMS LTI support for Tool Consumer and Tool Provider applications. Supports IMS LTI 1.0, 1.1, 1.1.1 and 1.2; Outcomes 1.0; Outcomes 2.0 (Draft); and Content-Item Message 1.0.",
+  "copyright": "Copyright © 2016",
+  "packOptions": {
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/andyfmiller/LtiLibrary.git"
+    },
+    "licenseUrl": "https://github.com/andyfmiller/LtiLibrary/blob/master/LICENSE",
+    "summary": ".NET library with IMS LTI support for Tool Consumer and Tool Provider applications. Supports IMS LTI 1.0, 1.1, 1.1.1 and 1.2; Outcomes 1.0; Outcomes 2.0 (Draft); and Content-Item Message 1.0."
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "8.0.3"
+  },
+  "frameworks": {
+    "net45": {
+      "frameworkAssemblies": {
+        "System.ComponentModel.DataAnnotations": "4.0.0.0",
+        "System.Net": "4.0.0.0",
+        "System.Net.Http": "4.0.0.0",
+        "System.Runtime.Serialization": "4.0.0.0",
+        "System.Xml": "4.0.0.0",
+        "System.Xml.Serialization": "4.0.0.0"
+      },
+      "dependencies": {
+        "Microsoft.Net.Http": "2.2.29"
+      }
+    },
+    "net46": {
+      "frameworkAssemblies": {
+        "System.ComponentModel.DataAnnotations": "4.0.0.0",
+        "System.Net": "4.0.0.0",
+        "System.Net.Http": "4.0.0.0",
+        "System.Runtime.Serialization": "4.0.0.0",
+        "System.Xml": "4.0.0.0",
+        "System.Xml.Serialization": "4.0.0.0"
+      },
+      "dependencies": {
+        "Microsoft.Net.Http": "2.2.29"
+      }
+    },
+    "netstandard1.5": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-24027",
+        "System.Collections.Specialized": "4.0.1-rc2-24027",
+        "System.ComponentModel.Annotations": "4.1.0-rc2-24027",
+        "System.ComponentModel.Primitives": "4.0.1-rc2-24027",
+        "System.Diagnostics.Debug": "4.0.11-rc2-24027",
+        "System.Dynamic.Runtime": "4.0.11-rc2-24027",
+        "System.Reflection.TypeExtensions": "4.1.0-rc2-24027",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
+        "System.Security.Cryptography.Algorithms": "4.1.0-rc2-24027",
+        "System.Xml.XmlSerializer": "4.0.11-rc2-24027"
+      },
+      "buildOptions": {
+        "define": [ "NetCore" ]
+      }
+    },
+    "netcoreapp1.0": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-24027",
+        "System.Collections.Specialized": "4.0.1-rc2-24027",
+        "System.ComponentModel.Annotations": "4.1.0-rc2-24027",
+        "System.ComponentModel.Primitives": "4.0.1-rc2-24027",
+        "System.Diagnostics.Debug": "4.0.11-rc2-24027",
+        "System.Dynamic.Runtime": "4.0.11-rc2-24027",
+        "System.Reflection.TypeExtensions": "4.1.0-rc2-24027",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
+        "System.Security.Cryptography.Algorithms": "4.1.0-rc2-24027",
+        "System.Xml.XmlSerializer": "4.0.11-rc2-24027"
+      },
+      "buildOptions": {
+        "define": [ "NetCore" ]
+      }
+    }
+  }
+}

--- a/LtiLibrary.NetCore.sln
+++ b/LtiLibrary.NetCore.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "LtiLibrary.Core", "LtiLibrary.Core\LtiLibrary.Core.xproj", "{E5DD5C8B-9B8C-4985-8C2A-A381DCE68F1A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E5DD5C8B-9B8C-4985-8C2A-A381DCE68F1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5DD5C8B-9B8C-4985-8C2A-A381DCE68F1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5DD5C8B-9B8C-4985-8C2A-A381DCE68F1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5DD5C8B-9B8C-4985-8C2A-A381DCE68F1A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
I've added support for netstandard1.5 and netcoreapp1.0 targets (LtiLibrary.Core). .NET 4.5 and 4.6 are supported as well. Now you can use LtiLibrary.Core.sln solution to compile for multiple targets. LtiLibrary.AspNet and Tests will be updated in the future.
